### PR TITLE
executor: polish RU v2 accounting metadata

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -386,10 +386,10 @@ type RUV2Config struct {
 	// ExecutorL1 is the weight for fast-path executors that scale by cells:
 	// BatchPointGet, PointGet, and Limit.
 	ExecutorL1 float64 `toml:"executor-l1" json:"executor-l1"`
-	// ExecutorL2 is the weight for general executors, including HashAgg,
+	// ExecutorL2 is the weight for general executors, including Expand, HashAgg,
 	// HashJoin, IndexLookUpJoin, IndexLookUpExecutor, IndexReaderExecutor,
-	// MemTableReaderExec, SelectionExec, TableDualExec, TableReaderExecutor,
-	// UnionScanExec, and SelectLockExec.
+	// MemTableReaderExec, MergeJoin, Projection, SelectionExec, SelectLockExec,
+	// TableDualExec, TableReaderExecutor, TopN, UnionScanExec, and Window.
 	ExecutorL2 float64 `toml:"executor-l2" json:"executor-l2"`
 	// ExecutorL3 is the weight for heavier operators: Sort and StreamAgg.
 	ExecutorL3 float64 `toml:"executor-l3" json:"executor-l3"`

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -448,8 +448,8 @@ result-chunk-cells = 0.00010000
 executor-l1 = 0.00013278
 # executor-l2 covers general executors:
 # HashAgg, HashJoin, IndexLookUpJoin, IndexLookUpExecutor, IndexReaderExecutor,
-# MemTableReaderExec, SelectionExec, TableDualExec, TableReaderExecutor,
-# UnionScanExec, and SelectLockExec.
+# MemTableReaderExec, MergeJoin, Projection, SelectionExec, SelectLockExec,
+# TableDualExec, TableReaderExecutor, TopN, UnionScanExec, Window, and Expand.
 executor-l2 = 0.00000383
 # executor-l3 covers heavier operators: Sort and StreamAgg.
 executor-l3 = 0.00141739

--- a/pkg/executor/adapter_test.go
+++ b/pkg/executor/adapter_test.go
@@ -499,10 +499,16 @@ func TestFinishExecuteStmtSyncsTiDBRUV2FromRUDetails(t *testing.T) {
 	}
 	ruDetails.AddRUV2(rawRUV2)
 	ruDetails.UpdateTiFlash(&rmpb.Consumption{RRU: 345, WRU: 67})
+	commitDetails := &util.CommitDetails{
+		WriteKeys: 3,
+		WriteSize: 66,
+	}
+	sessVars.StmtCtx.SyncExecDetails.MergeExecDetails(commitDetails)
 	// Build expected metrics by cloning the current state and manually adding
-	// the RUV2 counters (without draining ruDetails, since FinishExecuteStmt will drain).
+	// the pending counters (without draining ruDetails, since FinishExecuteStmt will drain).
 	expected := sessVars.RUV2Metrics.Clone()
 	execdetails.UpdateRUV2MetricsFromRUV2(expected, rawRUV2)
+	execdetails.UpdateRUV2MetricsFromCommitDetails(expected, commitDetails)
 
 	execStmt := &executor.ExecStmt{
 		Ctx:      ctx,
@@ -515,6 +521,8 @@ func TestFinishExecuteStmtSyncsTiDBRUV2FromRUDetails(t *testing.T) {
 	require.Equal(t, int64(5), sessVars.RUV2Metrics.ResourceManagerReadCnt())
 	require.Equal(t, int64(7), sessVars.RUV2Metrics.ResourceManagerWriteCnt())
 	require.Equal(t, int64(11), sessVars.RUV2Metrics.TiKVStorageProcessedKeysBatchGet())
+	require.Equal(t, int64(3), sessVars.RUV2Metrics.WriteKeys())
+	require.Equal(t, int64(66), sessVars.RUV2Metrics.WriteSize())
 	require.Equal(t, "rg1", reporter.group)
 	require.Equal(t, float64(23456), reporter.tikvRUV2)
 	require.Equal(t, expected.CalculateRUValues(sessVars.RUV2Weights()), reporter.tidbRUV2)

--- a/pkg/executor/internal/exec/executor_test.go
+++ b/pkg/executor/internal/exec/executor_test.go
@@ -72,7 +72,22 @@ func TestNextIOAccAddInputCountsRowsWithZeroCols(t *testing.T) {
 
 func TestRUV2ExecutorMetricByTypeIncludesConcreteExecutorTypes(t *testing.T) {
 	cases := map[string]ruv2ExecutorMetric{
+		"*aggregate.HashAggExec":        {level: 2, label: "HashAggExec", useCells: false},
+		"*aggregate.StreamAggExec":      {level: 3, label: "StreamAggExec", useCells: false},
+		"*executor.BatchPointGetExec":   {level: 1, label: "BatchPointGetExec", useCells: true},
+		"*executor.ExpandExec":          {level: 2, label: "ExpandExec", useCells: false},
+		"*executor.IndexLookUpExecutor": {level: 2, label: "IndexLookUpExecutor", useCells: false},
+		"*executor.IndexReaderExecutor": {level: 2, label: "IndexReaderExecutor", useCells: false},
+		"*executor.LimitExec":           {level: 1, label: "LimitExec", useCells: true},
+		"*executor.MemTableReaderExec":  {level: 2, label: "MemTableReaderExec", useCells: false},
+		"*executor.PointGetExecutor":    {level: 1, label: "PointGetExecutor", useCells: true},
 		"*executor.ProjectionExec":      {level: 2, label: "ProjectionExec", useCells: true},
+		"*executor.SelectLockExec":      {level: 2, label: "SelectLockExec", useCells: true},
+		"*executor.SelectionExec":       {level: 2, label: "SelectionExec", useCells: false},
+		"*executor.TableDualExec":       {level: 2, label: "TableDualExec", useCells: false},
+		"*executor.TableReaderExecutor": {level: 2, label: "TableReaderExecutor", useCells: false},
+		"*executor.UnionScanExec":       {level: 2, label: "UnionScanExec", useCells: false},
+		"*executor.WindowExec":          {level: 2, label: "WindowExec", useCells: false},
 		"*join.HashJoinV1Exec":          {level: 2, label: "HashJoinV1Exec", useCells: false},
 		"*join.HashJoinV2Exec":          {level: 2, label: "HashJoinV2Exec", useCells: false},
 		"*join.IndexLookUpJoin":         {level: 2, label: "IndexLookUpJoin", useCells: true},

--- a/pkg/metrics/metrics_internal_test.go
+++ b/pkg/metrics/metrics_internal_test.go
@@ -56,6 +56,45 @@ func countCollectedMetrics(collector prometheus.Collector) int {
 	return count
 }
 
+func TestRUV2ExecutorCounterReturnsCachedKnownLabels(t *testing.T) {
+	cases := []struct {
+		level    int
+		label    string
+		expected prometheus.Counter
+	}{
+		{1, "BatchPointGetExec", ruv2ExecutorL1BatchPointGetExec},
+		{1, "PointGetExecutor", ruv2ExecutorL1PointGetExecutor},
+		{1, "LimitExec", ruv2ExecutorL1LimitExec},
+		{2, "ExpandExec", ruv2ExecutorL2ExpandExec},
+		{2, "HashAggExec", ruv2ExecutorL2HashAggExec},
+		{2, "HashJoinExec", ruv2ExecutorL2HashJoinExec},
+		{2, "HashJoinV1Exec", ruv2ExecutorL2HashJoinV1Exec},
+		{2, "HashJoinV2Exec", ruv2ExecutorL2HashJoinV2Exec},
+		{2, "IndexLookUpJoin", ruv2ExecutorL2IndexLookUpJoin},
+		{2, "IndexLookUpMergeJoin", ruv2ExecutorL2IndexLookUpMergeJoin},
+		{2, "IndexNestedLoopHashJoin", ruv2ExecutorL2IndexNestedLoopHashJoin},
+		{2, "IndexLookUpExecutor", ruv2ExecutorL2IndexLookUpExec},
+		{2, "IndexReaderExecutor", ruv2ExecutorL2IndexReaderExec},
+		{2, "MemTableReaderExec", ruv2ExecutorL2MemTableReaderExec},
+		{2, "MergeJoinExec", ruv2ExecutorL2MergeJoinExec},
+		{2, "ProjectionExec", ruv2ExecutorL2ProjectionExec},
+		{2, "SelectionExec", ruv2ExecutorL2SelectionExec},
+		{2, "TableDualExec", ruv2ExecutorL2TableDualExec},
+		{2, "TableReaderExecutor", ruv2ExecutorL2TableReaderExec},
+		{2, "TopNExec", ruv2ExecutorL2TopNExec},
+		{2, "UnionScanExec", ruv2ExecutorL2UnionScanExec},
+		{2, "SelectLockExec", ruv2ExecutorL2SelectLockExec},
+		{2, "WindowExec", ruv2ExecutorL2WindowExec},
+		{3, "SortExec", ruv2ExecutorL3SortExec},
+		{3, "StreamAggExec", ruv2ExecutorL3StreamAggExec},
+	}
+
+	for _, tc := range cases {
+		require.NotNil(t, tc.expected, tc.label)
+		require.True(t, tc.expected == RUV2ExecutorCounter(tc.level, tc.label), tc.label)
+	}
+}
+
 func TestStmtSummaryMetricLabels(t *testing.T) {
 	InitStmtSummaryMetrics()
 	require.Equal(t, 0, countCollectedMetrics(StmtSummaryWindowRecordCount))

--- a/pkg/metrics/ru_v2.go
+++ b/pkg/metrics/ru_v2.go
@@ -49,17 +49,26 @@ var (
 	ruv2ExecutorL1PointGetExecutor  prometheus.Counter
 	ruv2ExecutorL1LimitExec         prometheus.Counter
 
-	ruv2ExecutorL2HashAggExec        prometheus.Counter
-	ruv2ExecutorL2HashJoinExec       prometheus.Counter
-	ruv2ExecutorL2IndexLookUpJoin    prometheus.Counter
-	ruv2ExecutorL2IndexLookUpExec    prometheus.Counter
-	ruv2ExecutorL2IndexReaderExec    prometheus.Counter
-	ruv2ExecutorL2MemTableReaderExec prometheus.Counter
-	ruv2ExecutorL2SelectionExec      prometheus.Counter
-	ruv2ExecutorL2TableDualExec      prometheus.Counter
-	ruv2ExecutorL2TableReaderExec    prometheus.Counter
-	ruv2ExecutorL2UnionScanExec      prometheus.Counter
-	ruv2ExecutorL2SelectLockExec     prometheus.Counter
+	ruv2ExecutorL2ExpandExec              prometheus.Counter
+	ruv2ExecutorL2HashAggExec             prometheus.Counter
+	ruv2ExecutorL2HashJoinExec            prometheus.Counter
+	ruv2ExecutorL2HashJoinV1Exec          prometheus.Counter
+	ruv2ExecutorL2HashJoinV2Exec          prometheus.Counter
+	ruv2ExecutorL2IndexLookUpJoin         prometheus.Counter
+	ruv2ExecutorL2IndexLookUpMergeJoin    prometheus.Counter
+	ruv2ExecutorL2IndexNestedLoopHashJoin prometheus.Counter
+	ruv2ExecutorL2IndexLookUpExec         prometheus.Counter
+	ruv2ExecutorL2IndexReaderExec         prometheus.Counter
+	ruv2ExecutorL2MemTableReaderExec      prometheus.Counter
+	ruv2ExecutorL2MergeJoinExec           prometheus.Counter
+	ruv2ExecutorL2ProjectionExec          prometheus.Counter
+	ruv2ExecutorL2SelectionExec           prometheus.Counter
+	ruv2ExecutorL2TableDualExec           prometheus.Counter
+	ruv2ExecutorL2TableReaderExec         prometheus.Counter
+	ruv2ExecutorL2TopNExec                prometheus.Counter
+	ruv2ExecutorL2UnionScanExec           prometheus.Counter
+	ruv2ExecutorL2SelectLockExec          prometheus.Counter
+	ruv2ExecutorL2WindowExec              prometheus.Counter
 
 	ruv2ExecutorL3SortExec      prometheus.Counter
 	ruv2ExecutorL3StreamAggExec prometheus.Counter
@@ -263,17 +272,26 @@ func initRUV2CachedLabelCounters() {
 	ruv2ExecutorL1PointGetExecutor = RUV2ExecutorL1.WithLabelValues("PointGetExecutor")
 	ruv2ExecutorL1LimitExec = RUV2ExecutorL1.WithLabelValues("LimitExec")
 
+	ruv2ExecutorL2ExpandExec = RUV2ExecutorL2.WithLabelValues("ExpandExec")
 	ruv2ExecutorL2HashAggExec = RUV2ExecutorL2.WithLabelValues("HashAggExec")
 	ruv2ExecutorL2HashJoinExec = RUV2ExecutorL2.WithLabelValues("HashJoinExec")
+	ruv2ExecutorL2HashJoinV1Exec = RUV2ExecutorL2.WithLabelValues("HashJoinV1Exec")
+	ruv2ExecutorL2HashJoinV2Exec = RUV2ExecutorL2.WithLabelValues("HashJoinV2Exec")
 	ruv2ExecutorL2IndexLookUpJoin = RUV2ExecutorL2.WithLabelValues("IndexLookUpJoin")
+	ruv2ExecutorL2IndexLookUpMergeJoin = RUV2ExecutorL2.WithLabelValues("IndexLookUpMergeJoin")
+	ruv2ExecutorL2IndexNestedLoopHashJoin = RUV2ExecutorL2.WithLabelValues("IndexNestedLoopHashJoin")
 	ruv2ExecutorL2IndexLookUpExec = RUV2ExecutorL2.WithLabelValues("IndexLookUpExecutor")
 	ruv2ExecutorL2IndexReaderExec = RUV2ExecutorL2.WithLabelValues("IndexReaderExecutor")
 	ruv2ExecutorL2MemTableReaderExec = RUV2ExecutorL2.WithLabelValues("MemTableReaderExec")
+	ruv2ExecutorL2MergeJoinExec = RUV2ExecutorL2.WithLabelValues("MergeJoinExec")
+	ruv2ExecutorL2ProjectionExec = RUV2ExecutorL2.WithLabelValues("ProjectionExec")
 	ruv2ExecutorL2SelectionExec = RUV2ExecutorL2.WithLabelValues("SelectionExec")
 	ruv2ExecutorL2TableDualExec = RUV2ExecutorL2.WithLabelValues("TableDualExec")
 	ruv2ExecutorL2TableReaderExec = RUV2ExecutorL2.WithLabelValues("TableReaderExecutor")
+	ruv2ExecutorL2TopNExec = RUV2ExecutorL2.WithLabelValues("TopNExec")
 	ruv2ExecutorL2UnionScanExec = RUV2ExecutorL2.WithLabelValues("UnionScanExec")
 	ruv2ExecutorL2SelectLockExec = RUV2ExecutorL2.WithLabelValues("SelectLockExec")
+	ruv2ExecutorL2WindowExec = RUV2ExecutorL2.WithLabelValues("WindowExec")
 
 	ruv2ExecutorL3SortExec = RUV2ExecutorL3.WithLabelValues("SortExec")
 	ruv2ExecutorL3StreamAggExec = RUV2ExecutorL3.WithLabelValues("StreamAggExec")
@@ -303,28 +321,46 @@ func RUV2ExecutorCounter(level int, label string) prometheus.Counter {
 		}
 	case 2:
 		switch label {
+		case "ExpandExec":
+			return ruv2ExecutorL2ExpandExec
 		case "HashAggExec":
 			return ruv2ExecutorL2HashAggExec
 		case "HashJoinExec":
 			return ruv2ExecutorL2HashJoinExec
+		case "HashJoinV1Exec":
+			return ruv2ExecutorL2HashJoinV1Exec
+		case "HashJoinV2Exec":
+			return ruv2ExecutorL2HashJoinV2Exec
 		case "IndexLookUpJoin":
 			return ruv2ExecutorL2IndexLookUpJoin
+		case "IndexLookUpMergeJoin":
+			return ruv2ExecutorL2IndexLookUpMergeJoin
+		case "IndexNestedLoopHashJoin":
+			return ruv2ExecutorL2IndexNestedLoopHashJoin
 		case "IndexLookUpExecutor":
 			return ruv2ExecutorL2IndexLookUpExec
 		case "IndexReaderExecutor":
 			return ruv2ExecutorL2IndexReaderExec
 		case "MemTableReaderExec":
 			return ruv2ExecutorL2MemTableReaderExec
+		case "MergeJoinExec":
+			return ruv2ExecutorL2MergeJoinExec
+		case "ProjectionExec":
+			return ruv2ExecutorL2ProjectionExec
 		case "SelectionExec":
 			return ruv2ExecutorL2SelectionExec
 		case "TableDualExec":
 			return ruv2ExecutorL2TableDualExec
 		case "TableReaderExecutor":
 			return ruv2ExecutorL2TableReaderExec
+		case "TopNExec":
+			return ruv2ExecutorL2TopNExec
 		case "UnionScanExec":
 			return ruv2ExecutorL2UnionScanExec
 		case "SelectLockExec":
 			return ruv2ExecutorL2SelectLockExec
+		case "WindowExec":
+			return ruv2ExecutorL2WindowExec
 		default:
 			return RUV2ExecutorL2.WithLabelValues(label)
 		}


### PR DESCRIPTION
## Summary

This is a follow-up cleanup on top of pingcap/tidb#68578.

- keep the cheap RUv2 Prometheus counter cache complete for newly added executor labels, without broadening the hot L1 recorder optimization
- expand executor type mapping coverage for all modeled concrete executor labels
- cover commit write keys/write size flowing through FinishExecuteStmt finalization
- refresh the executor L2 config comments to match the newly modeled executor set

## Notes

This does not change the RUv2 calculation formula. In particular, write_keys remains the only new commit-derived value included in TiDB RU calculation, and write_size remains a shadow metric.

This also keeps the existing insert-oriented executor_l5_insert_rows naming and comments unchanged to avoid extra terminology churn in this helper PR.

The original pingcap/tidb#68578 PR body/release-note block should still be refreshed separately so the release-note label can be cleared.

## Validation

- git diff --check
- go test -c -o /tmp/tidb-executor-internal-exec.test ./pkg/executor/internal/exec
- go test -c -o /tmp/tidb-execdetails.test ./pkg/util/execdetails
- go test -c -o /tmp/tidb-metrics.test ./pkg/metrics
- go test -c -o /tmp/tidb-executor.test ./pkg/executor
- go test -c -o /tmp/tidb-config.test ./pkg/config

Local runtime go test still hits the known github.com/shoenig/go-m1cpu cgo segfault on this Darwin/arm64 machine before test bodies execute. CGO_ENABLED=0 cannot build pkg/metrics because gosigar needs cgo-backed methods.